### PR TITLE
Upgrades plugin for IJ 2022.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@
 
 pluginGroup = com.github.brcosta.cljstuffplugin
 pluginName = clj-extras-plugin
-pluginVersion = 0.7.3
+pluginVersion = 0.7.4
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 203
-pluginUntilBuild = 221.*
+pluginUntilBuild = 222.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2020.3.4, 2021.1.3, 2021.2.4, 2021.3.3, 2022.1
+pluginVerifierIdeVersions = 2020.3.4, 2021.1.3, 2021.2.4, 2021.3.3, 2022.1, 2022.2
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC


### PR DESCRIPTION
Bumped supported plugin versions and ran verifier.

I'm not sure if bumping the plugin version was something I should have added to this PR or if that's handled by your release process.