### PR TITLE
Backslash fix for Windows

### DIFF
--- a/src/main/kotlin/com/github/brcosta/cljstuffplugin/actions/AnalyzeClasspathAction.kt
+++ b/src/main/kotlin/com/github/brcosta/cljstuffplugin/actions/AnalyzeClasspathAction.kt
@@ -72,8 +72,9 @@ open class AnalyzeClasspathAction : AnAction() {
                             log.info("built-in clj-kondo: Linting classpath file: ${file.path}")
 
                             val filePath = StringUtil.unescapeBackSlashes(file.path)
+                            val escapedConfigDir = StringUtil.escapeBackSlashes(configDir)
                             val config =
-                                "{:config-dir \"${configDir}\" :copy-configs true :dependencies true :lint [\"$filePath\"]}"
+                                "{:config-dir \"${escapedConfigDir}\" :copy-configs true :dependencies true :lint [\"$filePath\"]}"
 
                             indicator.text = "Analyzing '${file.path}'..."
                             indicator.fraction = index.toDouble() / pathsList.virtualFiles.size


### PR DESCRIPTION
This should fix #30. I think the problem was that the `configDir` was being constructed with a single backslash character, which works fine for actual file access, but chokes the EDN parser.

I'm a little new to plugin development, but I did at least verify via the grade `runIde` task that this no longer throws the exception on my local machine.