### PR TITLE
Update target branches for Dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,12 @@ updates:
   # Maintain dependencies for Gradle dependencies
   - package-ecosystem: "gradle"
     directory: "/"
-    target-branch: "next"
+    target-branch: "main"
     schedule:
       interval: "daily"
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "next"
+    target-branch: "main"
     schedule:
       interval: "daily"


### PR DESCRIPTION
`next` doesn't seem to exist anymore.
