### PR TITLE
Support IJ 2024.3, bump clj-kondo & upload-artifact action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       # Collect Tests Result of failed tests
       - name: Collect Tests Result
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: tests-result
           path: ${{ github.workspace }}/build/reports/tests
@@ -94,7 +94,7 @@ jobs:
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier
@@ -112,7 +112,7 @@ jobs:
 
       # Store already-built plugin as an artifact for downloading
       - name: Upload artifact
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact.outputs.filename }}
           path: ./build/distributions/content/*/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Upgrade plugin for IJ 2024.3
+- Update Built-in clj-kondo -> v2024.11.14
 
 ## 0.8.0
 - Upgrade plugin for IJ 2024.2 - Thanks R.A Porter (@coyotesqrl) for making it work :)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Upgrade plugin for IJ 2024.3
+
 ## 0.8.0
 - Upgrade plugin for IJ 2024.2 - Thanks R.A Porter (@coyotesqrl) for making it work :)
 - Update Built-in clj-kondo -> v2024.08.01

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.8.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 242
-pluginUntilBuild = 242.*
+pluginUntilBuild = 243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.brcosta.cljstuffplugin
 pluginName = clj-extras-plugin
-pluginVersion = 0.8.0
+pluginVersion = 0.8.1
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,4 +37,4 @@ gradleVersion = 8.2
 kotlin.stdlib.default.dependency = false
 
 # clj-kondo embedded version
-kondoVersion = clj-kondo:clj-kondo:2024.08.01
+kondoVersion = clj-kondo:clj-kondo:2024.11.14

--- a/src/main/kotlin/com/github/brcosta/cljstuffplugin/util/AppSettingsComponent.kt
+++ b/src/main/kotlin/com/github/brcosta/cljstuffplugin/util/AppSettingsComponent.kt
@@ -18,7 +18,7 @@ class AppSettingsComponent {
         panel = FormBuilder.createFormBuilder()
             .addLabeledComponent(
                 // TODO: get this from build.gradle
-                JBLabel("Clj-Kondo executable path (leave empty to use built-in version v2024.08.01):"),
+                JBLabel("Clj-Kondo executable path (leave empty to use built-in version v2024.11.14):"),
                 cljkondoPath,
                 1,
                 true


### PR DESCRIPTION
make this plugin capatable with IDEA2024.3 and fix pipeline failure in [this PR](https://github.com/brcosta/clj-extras-plugin/pull/66) 