### PR TITLE
fix deserialization failure & free runner disk space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,13 @@ jobs:
       changelog: ${{ steps.properties.outputs.changelog }}
       pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
     steps:
+      -
+      # Free GitHub Actions Environment Disk Space
+      - name: Maximize Build Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          large-packages: false
 
       # Check out the current repository
       - name: Fetch Sources
@@ -50,6 +57,7 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
+          cache: gradle
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       changelog: ${{ steps.properties.outputs.changelog }}
       pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
     steps:
-      -
+
       # Free GitHub Actions Environment Disk Space
       - name: Maximize Build Space
         uses: jlumbroso/free-disk-space@main
@@ -118,6 +118,7 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
+          cache: gradle
 
       # Setup Gradle
       - name: Setup Gradle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # clojure-extras-plugin Changelog
 
 ## [Unreleased]
+- Fix deserialization failure
 
+## 0.8.1
 - Upgrade plugin for IJ 2024.3
 - Update Built-in clj-kondo -> v2024.11.14
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.brcosta.cljstuffplugin
 pluginName = clj-extras-plugin
 pluginRepositoryUrl = https://github.com/brcosta/clj-extras-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.8.1
+pluginVersion = 0.8.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/src/main/kotlin/com/github/brcosta/cljstuffplugin/cljkondo/Diagnostics.kt
+++ b/src/main/kotlin/com/github/brcosta/cljstuffplugin/cljkondo/Diagnostics.kt
@@ -1,29 +1,46 @@
 package com.github.brcosta.cljstuffplugin.cljkondo
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class Diagnostics(val findings: List<Finding>, val summary: Summary?)
+data class Diagnostics(
+    @JsonProperty("findings") val findings: List<Finding>,
+    @JsonProperty("summary") val summary: Summary?
+)
 
 data class Finding(
+    @JsonProperty("row")
     val row: Int,
     @JsonProperty("end-row")
     val endRow: Int,
+    @JsonProperty("col")
     val col: Int,
     @JsonProperty("end-col")
     val endCol: Int,
+    @JsonProperty("level")
     val level: String,
+    @JsonProperty("filename")
     val filename: String?,
     @JsonProperty("class")
     val clazz: String?,
+    @JsonProperty("message")
     val message: String,
+    @JsonProperty("type")
     val type: String,
 )
 
 data class Summary(
-    var files: Int?,
+    @JsonProperty("files")
+    val files: Int?,
+    @JsonProperty("type")
     val type: String?,
+    @JsonProperty("error")
     val error: Int?,
+    @JsonProperty("warning")
     val warning: Int?,
+    @JsonProperty("info")
     val info: Int?,
+    @JsonProperty("duration")
     val duration: Int?
 )

--- a/src/main/kotlin/com/github/brcosta/cljstuffplugin/extensions/CljKondoAnnotator.kt
+++ b/src/main/kotlin/com/github/brcosta/cljstuffplugin/extensions/CljKondoAnnotator.kt
@@ -34,6 +34,7 @@ class CljKondoAnnotator : ExternalAnnotator<ExternalLintAnnotationInput, Externa
     private val log = Logger.getInstance(CljKondoAnnotator::class.java)
 
     private var runWithInStr = getWithInStr()
+
     private var print = getCheshirePrint()
 
     private val separators = " )".toCharArray()


### PR DESCRIPTION
I upgrade plugin by official marketplace today and got an error indicates output from clj-kondo cannot be deserialized,so code annotator is broken.
But this didn't happen before today, so weird.